### PR TITLE
automatic forward if  trailing slash is omitted

### DIFF
--- a/conf/nginx.conf.erb
+++ b/conf/nginx.conf.erb
@@ -11,6 +11,7 @@ http {
   types_hash_max_size 2048;
   include mime.types;
   server {
+    return 301 $scheme://$http_host$1;
     listen <%= ENV["PORT"] %>;
     server_name  _;
     <% if ENV["ROOT"] %>

--- a/conf/nginx.conf.erb
+++ b/conf/nginx.conf.erb
@@ -15,7 +15,7 @@ http {
       try_files $uri @rewrite;
     }
     location @rewrite {
-      return 302 $scheme://$http_host$uri/;
+      return 301 $scheme://$http_host$uri/;
     }
     listen <%= ENV["PORT"] %>;
     server_name  _;

--- a/conf/nginx.conf.erb
+++ b/conf/nginx.conf.erb
@@ -11,7 +11,12 @@ http {
   types_hash_max_size 2048;
   include mime.types;
   server {
-    return 301 $scheme://$http_host$1;
+    location ~ ^.*[^/]$ {
+      try_files $uri @rewrite;
+    }
+    location @rewrite {
+      return 302 $scheme://$http_host$uri/;
+    }
     listen <%= ENV["PORT"] %>;
     server_name  _;
     <% if ENV["ROOT"] %>


### PR DESCRIPTION
For hugo sites, posts are saved as subfolders. If the trailing slash is omitted in URLS a strange error appears. This fixes the issue by forwarding to a folder if the slash is missing.

